### PR TITLE
feat: add wrapper supporting no request params

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,30 @@ Go 1.18+ required
     )
 ```
 
-3. Write handler:
+3. Write handlers:
 ```go
+
+    // This handler supports request parameters
     func Multiply(ctx context.Context, args *Args) (int, error) {
         return args.A * args.B, nil
     }
+
+    // This handler has no request parameters
+    func Hello(ctx context.Context) (string, error) {
+        return "World", nil
+    }
 ```
 
-   Handler must have exact two arguments (context and input of any json serializable type) and exact two return values (output of any json serializable type and error)
+   A handler must have a context as first parameter and may have a second parameter, representing request paramters (input of any json serializable type). A handler always returns exactly two values (output of any json serializable type and error).
 
-4. Wrap handler with `rpc.H` method and register it in server:
+4. Wrap the handler using one of the two functions `rpc.H` (supporting req params) or `rpc.HS` (no params) and register it with the server:
+
 ```go
+    // handler has params
     s.Register("multiply", rpc.H(Multiply))
+
+    // handler has no params
+    s.Register("hello", rpc.HS(Hello))
 ```
 
 5. Run RPC server:
@@ -96,6 +108,7 @@ func main() {
 
    s.Register("multiply", rpc.H(Multiply))
    s.Register("divide", rpc.H(Divide))
+   s.Register("hello", rpc.HS(Hello))
 
    s.Run(context.Background())
 }
@@ -106,6 +119,10 @@ func Multiply(ctx context.Context, args *Args) (int, error) {
 
 func Divide(ctx context.Context, args *Args) (*Quotient, error) {
     //...
+}
+
+func Hello(ctx context.Context) (string, error) {
+	// ...
 }
 
 type Args struct {

--- a/example/main.go
+++ b/example/main.go
@@ -79,6 +79,7 @@ func main() {
 
 	s.Register("multiply", rpc.H(Multiply))
 	s.Register("divide", rpc.H(Divide))
+	s.Register("hello", rpc.HS(Hello))
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
@@ -100,6 +101,10 @@ func Divide(ctx context.Context, args *Args) (*Quotient, error) {
 	quo.Quo = args.A / args.B
 	quo.Rem = args.A % args.B
 	return quo, nil
+}
+
+func Hello(ctx context.Context) (string, error) {
+	return "world", nil
 }
 
 type Args struct {

--- a/rpc/wrapper.go
+++ b/rpc/wrapper.go
@@ -41,4 +41,18 @@ func H[RQ any, RS any](handler func(context.Context, *RQ) (RS, error)) HandlerFu
 	}
 }
 
+// HS is a simple generic wrapper for rpc handlers without any request params.
+func HS[RS any](handler func(context.Context) (RS, error)) HandlerFunc {
+	return func(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+		resp, err := handler(ctx)
+		if err != nil {
+			return nil, Error{
+				Code:    ErrUser,
+				Message: err.Error(),
+			}
+		}
+		return json.Marshal(resp)
+	}
+}
+
 type HandlerFunc func(context.Context, json.RawMessage) (json.RawMessage, error)


### PR DESCRIPTION
This PR adds support for requests without any parameters. Unfortunately I could figure out a way to modify the current handler to do the job without breaking anything so I added a second wrapper to support that use case. 

closes #2 